### PR TITLE
Updating dependencies and removing markdox to resolve 10 vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,11 @@
     "url": "https://github.com/lalitkapoor/request-cookies"
   },
   "dependencies": {
-    "tough-cookie": "0.12.x"
+    "tough-cookie": "4.0.0"
   },
   "devDependencies": {
-    "should": "2.1.x",
-    "mocha": "1.17.x",
-    "markdox": "0.1.x"
+    "mocha": "8.4.0",
+    "should": "13.2.3"
   },
   "scripts": {
     "test": "mocha test"


### PR DESCRIPTION
'npm install' resulted in a bunch of deprecation warnings and warnings about vulnerable dependencies.
>found 10 vulnerabilities (2 low, 1 moderate, 6 high, 1 critical)

I have updated all dependencies. That fixed most warnings. Unfortunately markdox has not been maintained and was pulling in a vulnerable version of lodash. Given markdox was a dev dependency and a tool used to generate the readme it doesn't strictly need to be in the repo so I have removed it pending it being updated.

The tests still pass after these changes.